### PR TITLE
Change dump location and move to backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 vagrant up master385-centos agent385-centos
 vagrant ssh master385-centos -c 'sudo /vagrant/files/migration_backup.sh'
 vagrant up master201620-centos
-vagrant ssh master201620-centos -c 'sudo /vagrant/files/migration_restore_post_install.sh'
+vagrant ssh master201620-centos -c 'sudo /vagrant/files/migration\_restore\_pre\_install.sh'
+vagrant ssh master201620-centos -c 'sudo /vagrant/files/migration\_restore\_post\_install.sh'
 vagrant provision agent385-centos --provision-with hosts
 vagrant ssh agent385-centos -c 'puppet agent -t --server master201620-centos'
 vagrant ssh master201620-centos

--- a/files/migration_backup.sh
+++ b/files/migration_backup.sh
@@ -2,7 +2,9 @@ BACKUP_DIR=/vagrant/files/backup
 
 tar -zcvf $BACKUP_DIR/puppet_ssl.tar.gz /etc/puppetlabs/puppet/ssl/
 
-sudo -u pe-postgres /opt/puppet/bin/pg_dump -Fc pe-puppetdb -f $BACKUP_DIR/pe-puppetdb.backup.bin
-sudo -u pe-postgres /opt/puppet/bin/pg_dump -Fc pe-classifier -f $BACKUP_DIR/pe-classifier.backup.bin
-sudo -u pe-postgres /opt/puppet/bin/pg_dump -Fc pe-rbac -f $BACKUP_DIR/pe-rbac.backup.bin
-sudo -u pe-postgres /opt/puppet/bin/pg_dump -Fc pe-activity -f $BACKUP_DIR/pe-activity.backup.bin
+sudo -u pe-postgres /opt/puppet/bin/pg_dump -Fc pe-puppetdb -f /tmp/pe-puppetdb.backup.bin
+sudo -u pe-postgres /opt/puppet/bin/pg_dump -Fc pe-classifier -f /tmp/pe-classifier.backup.bin
+sudo -u pe-postgres /opt/puppet/bin/pg_dump -Fc pe-rbac -f /tmp/pe-rbac.backup.bin
+sudo -u pe-postgres /opt/puppet/bin/pg_dump -Fc pe-activity -f /tmp/pe-activity.backup.bin
+
+mv /tmp/*.backup.bin $BACKUP_DIR/

--- a/files/migration_restore_post_install.sh
+++ b/files/migration_restore_post_install.sh
@@ -9,10 +9,16 @@ puppet resource service pe-activemq ensure=stopped
 puppet resource service pe-orchestration-services ensure=stopped
 puppet resource service pxp-agent ensure=stopped
 
-sudo -u pe-postgres /opt/puppetlabs/server/bin/pg_restore -Cc $BACKUP_DIR/pe-puppetdb.backup.bin -d template1
-sudo -u pe-postgres /opt/puppetlabs/server/bin/pg_restore -Cc $BACKUP_DIR/pe-classifier.backup.bin -d template1
-sudo -u pe-postgres /opt/puppetlabs/server/bin/pg_restore -Cc $BACKUP_DIR/pe-activity.backup.bin -d template1
-sudo -u pe-postgres /opt/puppetlabs/server/bin/pg_restore -Cc $BACKUP_DIR/pe-rbac.backup.bin -d template1
+mkdir -p /tmp/pe_postgres_restore
+
+cp $BACKUP_DIR/*.backup.bin /tmp/pe_postgres_restore
+
+sudo -u pe-postgres /opt/puppetlabs/server/bin/pg_restore -Cc /tmp/pe_postgres_restore/pe-puppetdb.backup.bin -d template1
+sudo -u pe-postgres /opt/puppetlabs/server/bin/pg_restore -Cc /tmp/pe_postgres_restore/pe-classifier.backup.bin -d template1
+sudo -u pe-postgres /opt/puppetlabs/server/bin/pg_restore -Cc /tmp/pe_postgres_restore/pe-activity.backup.bin -d template1
+sudo -u pe-postgres /opt/puppetlabs/server/bin/pg_restore -Cc /tmp/pe_postgres_restore/pe-rbac.backup.bin -d template1
+
+rm -rf /tmp/pe_postgres_restore/*
 
 #Start PE services
 #Install database extensions and repair database permissions


### PR DESCRIPTION
Otherwise you get something like this:

```
could not change directory to "/home/vagrant"
pg_dump: [custom archiver] could not open output file "/vagrant/files/backup/pe-puppetdb.backup.bin": Permission denied
could not change directory to "/home/vagrant"
pg_dump: [custom archiver] could not open output file "/vagrant/files/backup/pe-classifier.backup.bin": Permission denied
could not change directory to "/home/vagrant"
pg_dump: [custom archiver] could not open output file "/vagrant/files/backup/pe-rbac.backup.bin": Permission denied
could not change directory to "/home/vagrant"
pg_dump: [custom archiver] could not open output file "/vagrant/files/backup/pe-activity.backup.bin": Permission denied
```
